### PR TITLE
Output folders not created in project fixes #40

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,5 +107,5 @@ venv.bak/
 .idea/
 
 # Other
-output_graphs/
+output_files/
 test.py

--- a/input_output/file_output.py
+++ b/input_output/file_output.py
@@ -27,11 +27,14 @@ def load_graph_list(filename):
 
 def save_graph_as_dot(G, filename):
     """
-    This method saves a graph in a dot file  .
+    This method saves a graph in a dot file.
+    If folder /output_graphs/dot does not exist it is created
     :param G: The graph to be saved.
     :param filename: The filename in which the graph should be saved.
     """
     dot_filename = ROOT + '/output_graphs/dot/' + filename + '.dot'
+    os.makedirs(os.path.dirname(dot_filename), exist_ok=True)
+
     with open(dot_filename, 'w') as g0:
         write_dot(G, g0)
 
@@ -39,8 +42,12 @@ def save_graph_as_dot(G, filename):
 def save_graph_in_png(filename):
     """
     This method can use a .dot file and transform it into a png image of the graph.
+    If folder /output_graphs/dot or /output_graphs/png does not exist it is created
     :param filename: The filename of the .dot file without the extension, this will also be the filename for the .png file
     """
     dot_filename = ROOT + '/output_graphs/dot/' + filename + '.dot'
     png_filename = ROOT + '/output_graphs/png/' + filename + '.png'
+    os.makedirs(os.path.dirname(dot_filename), exist_ok=True)
+    os.makedirs(os.path.dirname(png_filename), exist_ok=True)
+
     subprocess.run(["dot", "-Tpng", dot_filename, "-o", png_filename])

--- a/input_output/file_output.py
+++ b/input_output/file_output.py
@@ -28,11 +28,11 @@ def load_graph_list(filename):
 def save_graph_as_dot(G, filename):
     """
     This method saves a graph in a dot file.
-    If folder /output_graphs/dot does not exist it is created
+    If folder /output_files/dot does not exist it is created
     :param G: The graph to be saved.
     :param filename: The filename in which the graph should be saved.
     """
-    dot_filename = ROOT + '/output_graphs/dot/' + filename + '.dot'
+    dot_filename = ROOT + '/output_files/dot/' + filename + '.dot'
     os.makedirs(os.path.dirname(dot_filename), exist_ok=True)
 
     with open(dot_filename, 'w') as g0:
@@ -42,11 +42,11 @@ def save_graph_as_dot(G, filename):
 def save_graph_in_png(filename):
     """
     This method can use a .dot file and transform it into a png image of the graph.
-    If folder /output_graphs/dot or /output_graphs/png does not exist it is created
+    If folder /output_files/dot or /output_files/png does not exist it is created
     :param filename: The filename of the .dot file without the extension, this will also be the filename for the .png file
     """
-    dot_filename = ROOT + '/output_graphs/dot/' + filename + '.dot'
-    png_filename = ROOT + '/output_graphs/png/' + filename + '.png'
+    dot_filename = ROOT + '/output_files/dot/' + filename + '.dot'
+    png_filename = ROOT + '/output_files/png/' + filename + '.png'
     os.makedirs(os.path.dirname(dot_filename), exist_ok=True)
     os.makedirs(os.path.dirname(png_filename), exist_ok=True)
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,9 @@ filename = 'test_graphs/color_refinement/' + file + '.grl'
 
 graphs = load_graph_list(filename)
 
+os.makedirs(os.path.dirname('output_graphs/main/'), exist_ok=True)
+
 for i in range(0, len(graphs)):
-    outputfilename = 'output_graphs/' + file + '_' + str(i) + '.dot'
+    outputfilename = 'output_graphs/main/' + file + '_' + str(i) + '.dot'
     with open(outputfilename, 'w') as g0:
         write_dot(color_refinement(degree_color_initialization(graphs[i])), g0)

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from input_output.file_output import load_graph_list
 from supporting_components.graph_io import *
 from algorithms.color_refinement import color_refinement
 from algorithms.color_initialization import degree_color_initialization
+import os
 
 # file = 'colorref_smallexample_4_7'
 file = 'colorref_smallexample_4_16'
@@ -11,9 +12,9 @@ filename = 'test_graphs/color_refinement/' + file + '.grl'
 
 graphs = load_graph_list(filename)
 
-os.makedirs(os.path.dirname('output_graphs/main/'), exist_ok=True)
+os.makedirs(os.path.dirname('output_files/main/'), exist_ok=True)
 
 for i in range(0, len(graphs)):
-    outputfilename = 'output_graphs/main/' + file + '_' + str(i) + '.dot'
+    outputfilename = 'output_files/main/' + file + '_' + str(i) + '.dot'
     with open(outputfilename, 'w') as g0:
         write_dot(color_refinement(degree_color_initialization(graphs[i])), g0)


### PR DESCRIPTION
Folders are automatically created if they do not exist.
The folder output_graphs has been renamed and refactored to output_files.
Also put the main.py output in a separate folder:
output_files/main/ instead of in /output_files/.