### PR TITLE
Fixed error if create_csv was False

### DIFF
--- a/tests/branching.py
+++ b/tests/branching.py
@@ -21,7 +21,7 @@ SETTING OF TEST
 # Set this variable to true if you want to show passed test results
 show_passed_results = False
 # Set this variable to true if you want to write all results to a csv file
-create_csv = True
+create_csv = False
 
 # Change here which files you want to evaluate
 torus24 = False
@@ -152,8 +152,9 @@ for i_file in i_files:
             print("Processing time amount_of_isomorphisms(G, H): " + str(amount_isomorph_time) + " s")
             print('')
 
-            csv_graph_result = [file, i, j, are_isomorph_time, are_isomorph_result, amount_isomorph_time, amount_isomorph_result]
-            write_csv_line(csv_filepath, csv_graph_result)
+            if create_csv:
+                csv_graph_result = [file, i, j, are_isomorph_time, are_isomorph_result, amount_isomorph_time, amount_isomorph_result]
+                write_csv_line(csv_filepath, csv_graph_result)
 
 print('-------------------------------')
 print("Statistics of branching test:")

--- a/tests/isomorphism_problem.py
+++ b/tests/isomorphism_problem.py
@@ -15,7 +15,7 @@ SETTING OF TEST
 # Set this variable to true if you want to show passed test results
 show_passed_results = False
 # Set this variable to true if you want to write all results to a csv file
-create_csv = True
+create_csv = False
 
 # todo: Add more test files? How can we do this easily so we can do it the 10th of April fast?
 # Change here which files you want to evaluate
@@ -145,8 +145,9 @@ for i_file in i_files:
             print("Processing time amount_of_isomorphisms(G, H): " + str(amount_isomorph_time) + " s")
             print('')
 
-            csv_graph_result = [file, i, j, are_isomorph_time, are_isomorph_result, amount_isomorph_time, amount_isomorph_result]
-            write_csv_line(csv_filepath, csv_graph_result)
+            if create_csv:
+                csv_graph_result = [file, i, j, are_isomorph_time, are_isomorph_result, amount_isomorph_time, amount_isomorph_result]
+                write_csv_line(csv_filepath, csv_graph_result)
 
 print('-------------------------------')
 print("Statistics of branching test:")


### PR DESCRIPTION
In de branching and isomorphism_problem tests, als create_csv False was, ontstond er een error omdat ergens in de file niet gechecked werd of je wel naar csv moest schrijven.