### PR TITLE
Added degree fixing before any other algorithm is run

### DIFF
--- a/algorithms/color_initialization.py
+++ b/algorithms/color_initialization.py
@@ -17,5 +17,5 @@ def twins_color_initialization(G: "Graph"):
     :return The graph with the initial coloring
     """
     for v in G.vertices:
-        v.colornum = v.twin_degree
+        v.colornum = v.degree_fixed
     return G

--- a/algorithms/preprocessing.py
+++ b/algorithms/preprocessing.py
@@ -5,6 +5,17 @@ from math import factorial
 from typing import List
 
 
+def fix_degrees(G: "Graph"):
+    """
+    Because the property 'degree' of vertices changes when the neighbours change, a property degree_fixed is added
+    to vertices to fix the degree of the vertex at this moment.
+    :param G:
+    :return:
+    """
+    for v in G.vertices:
+        v.degree_fixed = v.degree
+
+
 def could_be_isomorphic(G: 'Graph', H: 'Graph'):
     """
     Based on properties of the graphs a few simple comparisons are made to determine if the graphs could be isomorphic.
@@ -34,11 +45,9 @@ def remove_twins(G: 'Graph'):
     :return factor: To find the right amount of isomorphisms, the amount of isomorphisms found with the remaining
     graph should be multiplied by this factor.
     """
-    # First save degrees of vertices in twin_degree, so that will not change even though twins are removed
-    # Also put all vertices in a queue for evaluation
+    # Put all vertices in a queue for evaluation
     queue = []
     for v in G.vertices:
-        v.twin_degree = v.degree
         queue.append(v)
 
     factor = 1

--- a/supporting_components/graph.py
+++ b/supporting_components/graph.py
@@ -46,7 +46,7 @@ class Vertex(object):
         self.graph_label = graph_label
         self._incidence = {}
         self.colornum = None
-        self.twin_degree = None
+        self.degree_fixed = None
 
     def __repr__(self):
         """
@@ -369,10 +369,10 @@ class Graph(object):
 
         for v_before_union in self.vertices:
             vertex_reference_self[v_before_union] = Vertex(graph=disjoint_union_graph, graph_label=1)
-            vertex_reference_self[v_before_union].twin_degree = v_before_union.twin_degree
+            vertex_reference_self[v_before_union].degree_fixed = v_before_union.degree_fixed
         for v_before_union in other.vertices:
             vertex_reference_other[v_before_union] = Vertex(graph=disjoint_union_graph, graph_label=2)
-            vertex_reference_other[v_before_union].twin_degree = v_before_union.twin_degree
+            vertex_reference_other[v_before_union].degree_fixed = v_before_union.degree_fixed
 
         # Add edges
         # If vertex on Edge is not present when calling add.edge(), the vertex is added to the Graph object.
@@ -444,7 +444,7 @@ class Graph(object):
             vertices_old_to_new[v].label = v.label
             vertices_old_to_new[v].colornum = v.colornum
             vertices_old_to_new[v].graph_label = v.graph_label
-            vertices_old_to_new[v].twin_degree = v.twin_degree
+            vertices_old_to_new[v].degree_fixed = v.degree_fixed
 
         for e in self.edges:
             edge = Edge(vertices_old_to_new[e.tail], vertices_old_to_new[e.head])
@@ -469,7 +469,7 @@ class Graph(object):
                 return False
             for o in other_vertices:
                 if v.label == o.label:
-                    if v.graph_label != o.graph_label or v.colornum != o.colornum:
+                    if v.graph_label != o.graph_label or v.colornum != o.colornum or v.degree_fixed != o.degree_fixed:
                         return False
                     other_vertices.remove(o)
         return len(other_vertices) == 0

--- a/tests/integration_test/isomorphism_problem.py
+++ b/tests/integration_test/isomorphism_problem.py
@@ -1,3 +1,4 @@
+from algorithms.preprocessing import fix_degrees
 from tests.integration_test.algorithm_options import apply_could_be_isomorphic, apply_remove_twins, branching_method
 
 """
@@ -9,6 +10,8 @@ def are_isomorph(G: "Graph", H: "Graph"):
     :param G, H: The two graphs of which it must be determined if there is an isomorphism.
     :return: Boolean that indicates if graph G and H are isomorph or not.
     """
+    fix_degrees(G), fix_degrees(H)
+
     if not apply_could_be_isomorphic(G, H):
         return False
 
@@ -23,6 +26,8 @@ def amount_of_isomorphisms(G: "Graph", H: "Graph"):
     :param G, H: The two graphs of which the amount of isomorphisms must be determined.
     :return: Amount of isomorphisms graph G and H have.
     """
+    fix_degrees(G), fix_degrees(H)
+
     if not apply_could_be_isomorphic(G, H):
         return 0
 

--- a/tests/integration_test/run_integration_test.py
+++ b/tests/integration_test/run_integration_test.py
@@ -64,10 +64,13 @@ for filepath in file_paths:
             are_isomorph_actual = are_isomorph(G_copy, H_copy)
             end_isomorph = time()
 
+            G_copy = G.copy()
+            H_copy = H.copy()
             start_amount_isomorphisms = time()
-            amount_isomorph_actual = amount_of_isomorphisms(G, H)
+            amount_isomorph_actual = amount_of_isomorphisms(G_copy, H_copy)
             end_amount_isomorphisms = time()
 
+            test_failed = False
             # If solution of file is in solutions.py, check if solution is correct
             if bool(solution_map):
                 test_graph_count += 1
@@ -83,7 +86,7 @@ for filepath in file_paths:
                     if not are_isomorph_actual:
                         if console_fail:
                             fail("[FAIL] Graphs are isomorph, is_isomorph(G, H) did not detect it")
-                        error_count += 1
+                        test_failed = True
                         are_isomorph_passed = False
                     else:
                         if console_pass:
@@ -94,7 +97,7 @@ for filepath in file_paths:
                         if amount_isomorph_actual != amount_isomorph_expected:
                             if console_fail:
                                 fail("[FAIL] Amount of isomorphisms should be " + str(amount_isomorph_expected) + ", not " + str(amount_isomorph_actual))
-                            error_count += 1
+                            test_failed = True
                             amount_isomorph_passed = False
                         else:
                             if console_pass:
@@ -104,7 +107,7 @@ for filepath in file_paths:
                     if are_isomorph_actual:
                         if console_fail:
                             fail("[FAIL] Graphs are not isomorph, is_isomorph determined they were")
-                        error_count += 1
+                        test_failed = True
                         are_isomorph_passed = False
                     else:
                         if console_pass:
@@ -116,6 +119,8 @@ for filepath in file_paths:
                 amount_isomorph_expected = '-'
                 amount_isomorph_passed = '-'
 
+            if test_failed:
+                error_count += 1
 
             are_isomorph_time = round((end_isomorph - start_isomorph), 3)
             amount_isomorph_time = round((end_amount_isomorphisms - start_amount_isomorphisms), 3)


### PR DESCRIPTION
Toen ik met de trees bezig was kwam ik erachter dat het handig is om voordat er een algoritme wordt aangeroepen de degrees op dat moment vast te leggen in de aparte grafen, omdat niet elk algoritme de disjoint union gebruikt. En omdat ik wil voorkomen teveel in 1 PR te doen heb ik het even in een losse PR gedaan.

Verder kwam ik er ook achter dat in de integration test wel elke keer een kopie gemaakt moet worden bij de tests are_isomorph en amount_of_isomorphisms, omdat je meerdere keren over bijvoorbeeld graaf [0] loopt. En hij verandert dan toch al voor de volgende loop, dus dat moeten we voorkomen.