### PR TITLE
Added backup and revert method to graph, copy in branching not needed

### DIFF
--- a/algorithms/branching.py
+++ b/algorithms/branching.py
@@ -34,6 +34,7 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
 
     # Get the colors and its vertices and the maximum color number of the current graph
     colors, max_colornum = get_colors(G)
+    max_colornum += 1
 
     # Choose the color class C with at least 4 vertices of that color in the graph
     # Choose color class with smallest amount of vertices
@@ -50,13 +51,13 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
             break
 
     # Change the color of this vertex to a new color and append it to the list of fixed vertices for the first graph
-    x.colornum = max_colornum + 1
+    x.colornum = max_colornum
     D.append(x)
     # Create branches for all the possible fixed pairs of vertices for the chosen color
-    return __branching(G, colors, C, D.copy(), I.copy(), count_flag, color_refinement_method)
+    return __branching(G, colors, max_colornum, C, D.copy(), I.copy(), count_flag, color_refinement_method)
 
 
-def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', C: 'Int', D: 'List[Vertex]', I: 'List[Vertex]', count_flag: 'Bool', color_refinement_method: Callable[[Graph], None]):
+def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', max_colornum, C: 'Int', D: 'List[Vertex]', I: 'List[Vertex]', count_flag: 'Bool', color_refinement_method: Callable[[Graph], None]):
     """
     Creates branches of the graph (disjoint union of two graphs) and count the amount of isomorphisms for those graphs.
     In one graph, one vertex of the color group is fixed. For each of the vertices in the other graph, a branch is
@@ -80,20 +81,17 @@ def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', C: 'Int', D: 'Lis
     # For each of the vertices in the list of vertices with color C, fix the vertex and change its color to the new
     # color and determine the amount of isomorphisms for the resulting graph
     num_isomorphisms = 0
-    for y0 in g1:
+    for y in g1:
         # Make a copy of everything before creating a new branch
-        G_copy = G.copy()
+        G_backup = G.backup()
         D_copy = D.copy()
         I_copy = I.copy()
-        colors_copy, max_colornum = get_colors(G_copy)
-        for y in colors_copy[C]:
-            if y.graph_label == 2 and y.label == y0.label:
-                y.colornum = max_colornum
-                I_copy.append(y)
-                num_isomorphisms += count_isomorphisms(G_copy, D_copy, I_copy, count_flag, color_refinement_method)
-                if not count_flag and num_isomorphisms > 0:
-                    return True
-                break
+        y.colornum = max_colornum
+        I_copy.append(y)
+        num_isomorphisms += count_isomorphisms(G, D_copy, I_copy, count_flag, color_refinement_method)
+        if not count_flag and num_isomorphisms > 0:
+            return True
+        G.revert(G_backup)
     if not count_flag:
         return num_isomorphisms > 0
     else:

--- a/supporting_components/graph.py
+++ b/supporting_components/graph.py
@@ -4,7 +4,7 @@ This is a module for working with directed and undirected multigraphs.
 # version: 29-01-2015, Paul Bonsma
 # version: 01-02-2017, Pieter Bos, Tariq Bontekoe
 
-from typing import List, Union, Set
+from typing import List, Union, Set, Dict
 
 
 class GraphError(Exception):
@@ -473,6 +473,16 @@ class Graph(object):
                         return False
                     other_vertices.remove(o)
         return len(other_vertices) == 0
+
+    def backup(self):
+        color_list = {}
+        for v in self.vertices:
+            color_list[v.label] = v.colornum
+        return color_list
+
+    def revert(self, color_list: "Dict[int]"):
+        for v in self.vertices:
+            v.colornum = color_list[v.label]
 
 
 class UnsafeGraph(Graph):


### PR DESCRIPTION
Om geen copy() meer te gebruiken in de branching. Heb ik aan de graph een backup() en revert() methode toegevoegd, zodat we tussendoor onze graph G weer terug kunnen zetten naar een vorige graph in plaats van steeds een copy() te gebruiken.