### PR TITLE
Max colornum in graph

### DIFF
--- a/algorithms/branching.py
+++ b/algorithms/branching.py
@@ -33,8 +33,7 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
         return 1
 
     # Get the colors and its vertices and the maximum color number of the current graph
-    colors, max_colornum = get_colors(G)
-    max_colornum += 1
+    colors, unused = get_colors(G)
 
     # Choose the color class C with at least 4 vertices of that color in the graph
     # Choose color class with smallest amount of vertices
@@ -51,13 +50,13 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
             break
 
     # Change the color of this vertex to a new color and append it to the list of fixed vertices for the first graph
-    x.colornum = max_colornum
+    x.colornum = G.max_colornum + 1
     D.append(x)
     # Create branches for all the possible fixed pairs of vertices for the chosen color
-    return __branching(G, colors, max_colornum, C, D.copy(), I.copy(), count_flag, color_refinement_method)
+    return __branching(G, colors, C, D.copy(), I.copy(), count_flag, color_refinement_method)
 
 
-def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', max_colornum, C: 'Int', D: 'List[Vertex]', I: 'List[Vertex]', count_flag: 'Bool', color_refinement_method: Callable[[Graph], None]):
+def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', C: 'Int', D: 'List[Vertex]', I: 'List[Vertex]', count_flag: 'Bool', color_refinement_method: Callable[[Graph], None]):
     """
     Creates branches of the graph (disjoint union of two graphs) and count the amount of isomorphisms for those graphs.
     In one graph, one vertex of the color group is fixed. For each of the vertices in the other graph, a branch is
@@ -83,15 +82,16 @@ def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', max_colornum, C: 
     num_isomorphisms = 0
     for y in g1:
         # Make a copy of everything before creating a new branch
-        G_backup = G.backup()
+        G_backup, max_colornum = G.backup()
+        G.max_colornum += 1
         D_copy = D.copy()
         I_copy = I.copy()
-        y.colornum = max_colornum
+        y.colornum = G.max_colornum
         I_copy.append(y)
         num_isomorphisms += count_isomorphisms(G, D_copy, I_copy, count_flag, color_refinement_method)
         if not count_flag and num_isomorphisms > 0:
             return True
-        G.revert(G_backup)
+        G.revert(G_backup, max_colornum)
     if not count_flag:
         return num_isomorphisms > 0
     else:

--- a/algorithms/branching.py
+++ b/algorithms/branching.py
@@ -32,8 +32,8 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
             return True
         return 1
 
-    # Get the colors and its vertices and the maximum color number of the current graph
-    colors, unused = get_colors(G)
+    # Get the colors and its vertices of the current graph
+    colors = get_colors(G)
 
     # Choose the color class C with at least 4 vertices of that color in the graph
     # Choose color class with smallest amount of vertices
@@ -82,7 +82,7 @@ def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', C: 'Int', D: 'Lis
     num_isomorphisms = 0
     for y in g1:
         # Make a copy of everything before creating a new branch
-        G_backup, max_colornum = G.backup()
+        G_backup, max_colornum_backup = G.backup()
         G.max_colornum += 1
         D_copy = D.copy()
         I_copy = I.copy()
@@ -91,7 +91,7 @@ def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', C: 'Int', D: 'Lis
         num_isomorphisms += count_isomorphisms(G, D_copy, I_copy, count_flag, color_refinement_method)
         if not count_flag and num_isomorphisms > 0:
             return True
-        G.revert(G_backup, max_colornum)
+        G.revert(G_backup, max_colornum_backup)
     if not count_flag:
         return num_isomorphisms > 0
     else:

--- a/algorithms/color_initialization.py
+++ b/algorithms/color_initialization.py
@@ -1,11 +1,16 @@
 def degree_color_initialization(G: "Graph"):
     """
     Initializes the colornum properties of all vertices in graph G based on the degree of the vertices.
+    Initializes the max_colornum property of the graph as well.
     :param G: The graph to be initialized
     :return The graph with the initial coloring
     """
+    max_colornum = 0
     for v in G.vertices:
         v.colornum = v.degree
+        if v.colornum > max_colornum:
+            max_colornum = v.colornum
+    G.max_colornum = max_colornum
     return G
 
 
@@ -13,9 +18,14 @@ def twins_color_initialization(G: "Graph"):
     """
     Initializes the colornum properties of all vertices in graph G based on the degree of the vertices when twins
     have been removed.
+    Initializes the max_colornum property of the graph as well.
     :param G: The graph to be initialized
     :return The graph with the initial coloring
     """
+    max_colornum = 0
     for v in G.vertices:
         v.colornum = v.degree_fixed
+        if v.colornum > max_colornum:
+            max_colornum = v.colornum
+    G.max_colornum = max_colornum
     return G

--- a/algorithms/color_refinement.py
+++ b/algorithms/color_refinement.py
@@ -11,7 +11,7 @@ def color_refinement(G: "Graph"):
     """
 
     # Get the current distribution of colors over the vertices and the maximum colornum in the graph
-    colors, max_colornum = get_colors(G)
+    colors, unused = get_colors(G)
 
     has_changed = True
     while has_changed:
@@ -20,8 +20,8 @@ def color_refinement(G: "Graph"):
             if len(vertices) == 1:
                 continue
 
-            max_colornum += 1
-            has_changed = __colorgroup_refinement(colors, colornum, vertices, max_colornum) or has_changed
+            G.max_colornum += 1
+            has_changed = __colorgroup_refinement(colors, colornum, vertices, G.max_colornum) or has_changed
     return G
 
 
@@ -44,7 +44,7 @@ def fast_color_refinement(G: "Graph"):
         # Get first color and remove that from the queue
         color = queue.pop(0)
         # Get the vertices of the graph in the color group currently investigated
-        colors, max_colornum = get_colors(G)
+        colors, unused = get_colors(G)
         vertices_in_color_group = colors[color]
         # Get the neighbours of the color group grouped by color
         neighbours_of_color_group = __get_color_groups_with_neighbours_in_color_group(vertices_in_color_group)
@@ -53,19 +53,19 @@ def fast_color_refinement(G: "Graph"):
             if len(color_group) == 0 or len(color_group) == len(colors[c]):
                 continue
             # Change the color of the vertices in neighbours_of_color_group
-            max_colornum = max_colornum + 1
+            G.max_colornum += 1
             for vertex in color_group:
-                vertex.colornum = max_colornum
+                vertex.colornum = G.max_colornum
             # Add the correct color to the queue
             if c in queue:
-                queue.append(max_colornum)
+                queue.append(G.max_colornum)
             else:
                 # Append the current color to the queue if the amount of vertices that did not change color is larger
                 # than the amount of vertices that did change color
                 if 2 * len(color_group) < len(colors[c]):
                     queue.append(c)
                 else:
-                    queue.append(max_colornum)
+                    queue.append(G.max_colornum)
     return G
 
 
@@ -145,7 +145,7 @@ def __initialize_queue(G: "Graph"):
     :param G: The graph to construct the queue for
     :return: The queue of the graph
     """
-    colors, max_colornum = get_colors(G)
+    colors, unused = get_colors(G)
     queue = list(colors.keys())
     largest_color_group_size = 0
     largest_color_group = 0

--- a/algorithms/color_refinement.py
+++ b/algorithms/color_refinement.py
@@ -10,8 +10,8 @@ def color_refinement(G: "Graph"):
     :return: Finished colored graph
     """
 
-    # Get the current distribution of colors over the vertices and the maximum colornum in the graph
-    colors, unused = get_colors(G)
+    # Get the current distribution of colors over the vertices
+    colors = get_colors(G)
 
     has_changed = True
     while has_changed:
@@ -44,7 +44,7 @@ def fast_color_refinement(G: "Graph"):
         # Get first color and remove that from the queue
         color = queue.pop(0)
         # Get the vertices of the graph in the color group currently investigated
-        colors, unused = get_colors(G)
+        colors = get_colors(G)
         vertices_in_color_group = colors[color]
         # Get the neighbours of the color group grouped by color
         neighbours_of_color_group = __get_color_groups_with_neighbours_in_color_group(vertices_in_color_group)
@@ -72,17 +72,14 @@ def fast_color_refinement(G: "Graph"):
 def get_colors(G: "Graph"):
     """
     Returns a map with the colors of the graph as keys and a list of all the vertices in the graph with that color as
-    values and the maximum colornum property in the graph.
-    :param G: The graph.
-    :return: The color map and the maximum colornum
+    values.
+    :param G: The graph
+    :return: The color map
     """
     colors = {}
-    max_colornum = 0
     for v in G.vertices:
         colors.setdefault(v.colornum, []).append(v)
-        if v.colornum > max_colornum:
-            max_colornum = v.colornum
-    return colors, max_colornum
+    return colors
 
 
 def __colorgroup_refinement(colors, colornum, vertices: List["Vertex"], next_colornum):
@@ -145,7 +142,7 @@ def __initialize_queue(G: "Graph"):
     :param G: The graph to construct the queue for
     :return: The queue of the graph
     """
-    colors, unused = get_colors(G)
+    colors = get_colors(G)
     queue = list(colors.keys())
     largest_color_group_size = 0
     largest_color_group = 0

--- a/supporting_components/graph.py
+++ b/supporting_components/graph.py
@@ -225,6 +225,7 @@ class Graph(object):
         self._simple = simple
         self._directed = directed
         self._next_label_value = 0
+        self.max_colornum = 0
 
         for i in range(n):
             self.add_vertex(Vertex(self))
@@ -437,6 +438,7 @@ class Graph(object):
         :return: The copy of the graph.
         """
         copy = Graph(self.directed)
+        copy.max_colornum = self.max_colornum
         vertices_old_to_new = {}
 
         for v in self.vertices:

--- a/supporting_components/graph.py
+++ b/supporting_components/graph.py
@@ -480,11 +480,12 @@ class Graph(object):
         color_list = {}
         for v in self.vertices:
             color_list[v.label] = v.colornum
-        return color_list
+        return color_list, self.max_colornum
 
-    def revert(self, color_list: "Dict[int]"):
+    def revert(self, color_list: "Dict[int]", max_colornum):
         for v in self.vertices:
             v.colornum = color_list[v.label]
+        self.max_colornum = max_colornum
 
 
 class UnsafeGraph(Graph):


### PR DESCRIPTION
Ik heb de max_colornum property uit de methode get_colors gehaald en als een property opgeslagen in de graaf. Deze property wordt nu geinitialiseerd in de color_initialization, dus of bij de degree coloring of bij de twin coloring. Daarna wordt de property telkens uit de graaf gehaald wanneer deze nodig is. 

Helaas scheelt het in tijd niet zoveel, voor Trees90 gaat de tijd van get_colors van 11.293 naar 9.906 en de totale tijd van Trees90 gaat van 156.818 naar 154.454. Ik gok dat de kleine tijdwinst hem zit in dat iedere keer voor get_colors niet hoeft te worden vergeleken of de huidige max_colornum kleiner is dan de colornum van een vertex, het scheelt je dus een if loop daar. Die if loop is dus nu verplaatst naar de color initialization en daarna wordt deze iedere keer weer geupdate. 

Ik gok wel dat ik straks problemen krijg met de PR van vera met de backup en revert methode van de graaf. Daarin moet ook deze property -1 worden gedaan denk ik.