### PR TITLE
Color map in graph, fixes #80

### DIFF
--- a/algorithms/branching.py
+++ b/algorithms/branching.py
@@ -31,19 +31,16 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
             return True
         return 1
 
-    # Get the colors and its vertices of the current graph
-    colors = G.colors
-
     # Choose the color class C with at least 4 vertices of that color in the graph
     # Choose color class with smallest amount of vertices
     C_len = inf
-    for key in colors:
-        if len(colors[key]) >= 4 and len(colors[key]) < C_len:
+    for key in G.colors:
+        if len(G.colors[key]) >= 4 and len(G.colors[key]) < C_len:
             C = key
-            C_len = len(colors[key])
+            C_len = len(G.colors[key])
 
     # Choose the first occurring vertex with color C in the list of vertices of the first graph
-    for v in colors[C]:
+    for v in G.colors[C]:
         if v.graph_label == 1:
             x = v
             break
@@ -51,8 +48,8 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
     # Change the color of this vertex to a new color and append it to the list of fixed vertices for the first graph
     x.colornum = G.max_colornum + 1
     # Update colors of graph
-    colors[C].remove(x)
-    colors.setdefault(G.max_colornum + 1, list()).append(x)
+    G.colors[C].remove(x)
+    G.colors.setdefault(G.max_colornum + 1, list()).append(x)
     D.append(x)
     # Create branches for all the possible fixed pairs of vertices for the chosen color
     return __branching(G, C, D.copy(), I.copy(), count_flag, color_refinement_method)
@@ -84,7 +81,7 @@ def __branching(G: 'Graph', C: 'Int', D: 'List[Vertex]', I: 'List[Vertex]', coun
     num_isomorphisms = 0
     for y in g1:
         # Make a copy of everything before creating a new branch
-        G_backup, max_colornum_backup, colors_backup = G.backup()
+        color_list_backup, max_colornum_backup, colors_backup = G.backup()
         G.max_colornum += 1
         D_copy = D.copy()
         I_copy = I.copy()
@@ -96,7 +93,7 @@ def __branching(G: 'Graph', C: 'Int', D: 'List[Vertex]', I: 'List[Vertex]', coun
         num_isomorphisms += count_isomorphisms(G, D_copy, I_copy, count_flag, color_refinement_method)
         if not count_flag and num_isomorphisms > 0:
             return True
-        G.revert(G_backup, max_colornum_backup, colors_backup)
+        G.revert(color_list_backup, max_colornum_backup, colors_backup)
     if not count_flag:
         return num_isomorphisms > 0
     else:

--- a/algorithms/branching.py
+++ b/algorithms/branching.py
@@ -1,5 +1,4 @@
 from supporting_components.graph import Graph, Vertex
-from algorithms.color_refinement import get_colors
 from algorithms.decide_gi import is_balanced_or_bijected
 from typing import List, Dict, Callable
 from math import inf

--- a/algorithms/branching.py
+++ b/algorithms/branching.py
@@ -33,7 +33,7 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
         return 1
 
     # Get the colors and its vertices of the current graph
-    colors = get_colors(G)
+    colors = G.colors
 
     # Choose the color class C with at least 4 vertices of that color in the graph
     # Choose color class with smallest amount of vertices
@@ -51,12 +51,15 @@ def count_isomorphisms(G: 'Graph', D: 'List[Vertex]', I: 'List[Vertex]', count_f
 
     # Change the color of this vertex to a new color and append it to the list of fixed vertices for the first graph
     x.colornum = G.max_colornum + 1
+    # Update colors of graph
+    colors[C].remove(x)
+    colors.setdefault(G.max_colornum + 1, list()).append(x)
     D.append(x)
     # Create branches for all the possible fixed pairs of vertices for the chosen color
-    return __branching(G, colors, C, D.copy(), I.copy(), count_flag, color_refinement_method)
+    return __branching(G, C, D.copy(), I.copy(), count_flag, color_refinement_method)
 
 
-def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', C: 'Int', D: 'List[Vertex]', I: 'List[Vertex]', count_flag: 'Bool', color_refinement_method: Callable[[Graph], None]):
+def __branching(G: 'Graph', C: 'Int', D: 'List[Vertex]', I: 'List[Vertex]', count_flag: 'Bool', color_refinement_method: Callable[[Graph], None]):
     """
     Creates branches of the graph (disjoint union of two graphs) and count the amount of isomorphisms for those graphs.
     In one graph, one vertex of the color group is fixed. For each of the vertices in the other graph, a branch is
@@ -73,7 +76,7 @@ def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', C: 'Int', D: 'Lis
     """
     # Create the list of vertices in the other graph with color C
     g1 = []
-    for v in colors[C]:
+    for v in G.colors[C]:
         if v.graph_label == 2:
             g1.append(v)
 
@@ -82,16 +85,19 @@ def __branching(G: 'Graph', colors: 'Dict[Int, List[Vertex]]', C: 'Int', D: 'Lis
     num_isomorphisms = 0
     for y in g1:
         # Make a copy of everything before creating a new branch
-        G_backup, max_colornum_backup = G.backup()
+        G_backup, max_colornum_backup, colors_backup = G.backup()
         G.max_colornum += 1
         D_copy = D.copy()
         I_copy = I.copy()
         y.colornum = G.max_colornum
+        # Update colors of graph
+        G.colors[C].remove(y)
+        G.colors.setdefault(G.max_colornum, list()).append(y)
         I_copy.append(y)
         num_isomorphisms += count_isomorphisms(G, D_copy, I_copy, count_flag, color_refinement_method)
         if not count_flag and num_isomorphisms > 0:
             return True
-        G.revert(G_backup, max_colornum_backup)
+        G.revert(G_backup, max_colornum_backup, colors_backup)
     if not count_flag:
         return num_isomorphisms > 0
     else:

--- a/algorithms/color_initialization.py
+++ b/algorithms/color_initialization.py
@@ -2,15 +2,19 @@ def degree_color_initialization(G: "Graph"):
     """
     Initializes the colornum properties of all vertices in graph G based on the degree of the vertices.
     Initializes the max_colornum property of the graph as well.
+    Initializes colors, the map with vertices grouped by color, as well.
     :param G: The graph to be initialized
     :return The graph with the initial coloring
     """
     max_colornum = 0
+    colors = {}
     for v in G.vertices:
         v.colornum = v.degree
+        colors.setdefault(v.colornum, list()).append(v)
         if v.colornum > max_colornum:
             max_colornum = v.colornum
     G.max_colornum = max_colornum
+    G.colors = colors
     return G
 
 
@@ -19,13 +23,17 @@ def twins_color_initialization(G: "Graph"):
     Initializes the colornum properties of all vertices in graph G based on the degree of the vertices when twins
     have been removed.
     Initializes the max_colornum property of the graph as well.
+    Initializes colors, the map with vertices grouped by color, as well.
     :param G: The graph to be initialized
     :return The graph with the initial coloring
     """
     max_colornum = 0
+    colors = {}
     for v in G.vertices:
         v.colornum = v.degree_fixed
+        colors.setdefault(v.colornum, list()).append(v)
         if v.colornum > max_colornum:
             max_colornum = v.colornum
     G.max_colornum = max_colornum
+    G.colors = colors
     return G

--- a/algorithms/color_initialization.py
+++ b/algorithms/color_initialization.py
@@ -7,14 +7,13 @@ def degree_color_initialization(G: "Graph"):
     :return The graph with the initial coloring
     """
     max_colornum = 0
-    colors = {}
+    G.colors = {}
     for v in G.vertices:
         v.colornum = v.degree
-        colors.setdefault(v.colornum, list()).append(v)
+        G.colors.setdefault(v.colornum, list()).append(v)
         if v.colornum > max_colornum:
             max_colornum = v.colornum
     G.max_colornum = max_colornum
-    G.colors = colors
     return G
 
 
@@ -28,12 +27,11 @@ def twins_color_initialization(G: "Graph"):
     :return The graph with the initial coloring
     """
     max_colornum = 0
-    colors = {}
+    G.colors = {}
     for v in G.vertices:
         v.colornum = v.degree_fixed
-        colors.setdefault(v.colornum, list()).append(v)
+        G.colors.setdefault(v.colornum, list()).append(v)
         if v.colornum > max_colornum:
             max_colornum = v.colornum
     G.max_colornum = max_colornum
-    G.colors = colors
     return G

--- a/algorithms/color_refinement.py
+++ b/algorithms/color_refinement.py
@@ -10,18 +10,15 @@ def color_refinement(G: "Graph"):
     :return: Finished colored graph
     """
 
-    # Get the current distribution of colors over the vertices
-    colors = G.colors
-
     has_changed = True
     while has_changed:
         has_changed = False
-        for colornum, vertices in colors.copy().items():
+        for colornum, vertices in G.colors.copy().items():
             if len(vertices) == 1:
                 continue
 
             G.max_colornum += 1
-            has_changed = __colorgroup_refinement(colors, colornum, vertices, G.max_colornum) or has_changed
+            has_changed = __colorgroup_refinement(G, colornum, vertices, G.max_colornum) or has_changed
     return G
 
 
@@ -43,41 +40,39 @@ def fast_color_refinement(G: "Graph"):
     while queue:
         # Get first color and remove that from the queue
         color = queue.pop(0)
-        # Get the vertices of the graph in the color group currently investigated
-        colors = G.colors
-        vertices_in_color_group = colors[color]
+        vertices_in_color_group = G.colors[color]
         # Get the neighbours of the color group grouped by color
         neighbours_of_color_group = __get_color_groups_with_neighbours_in_color_group(vertices_in_color_group)
         for c, color_group in neighbours_of_color_group.items():
             # Do nothing if the size of the set in neighbours_of_color_group is zero or if the size is the same as the size of the list in colors
-            if len(color_group) == 0 or len(color_group) == len(colors[c]):
+            if len(color_group) == 0 or len(color_group) == len(G.colors[c]):
                 continue
             # Change the color of the vertices in neighbours_of_color_group
             G.max_colornum += 1
             for vertex in color_group:
                 vertex.colornum = G.max_colornum
                 # Update colors of graph
-                colors[c].remove(vertex)
-                colors.setdefault(G.max_colornum, list()).append(vertex)
+                G.colors[c].remove(vertex)
+                G.colors.setdefault(G.max_colornum, list()).append(vertex)
             # Add the correct color to the queue
             if c in queue:
                 queue.append(G.max_colornum)
             else:
                 # Append the current color to the queue if the amount of vertices that did not change color is larger
                 # than the amount of vertices that did change color
-                if 2 * len(color_group) < len(colors[c]):
+                if 2 * len(color_group) < len(G.colors[c]):
                     queue.append(c)
                 else:
                     queue.append(G.max_colornum)
     return G
 
 
-def __colorgroup_refinement(colors, colornum, vertices: List["Vertex"], next_colornum):
+def __colorgroup_refinement(G, colornum, vertices: List["Vertex"], next_colornum):
     """
     For vertices with property colornum = 'colornum', define which vertices have equal neighbours and which do not
     If a vertex within this group does not have the same neighbours as the first vertex in this group, these vertices
     will be given a new colornum 'next_colornum' and are moved from key colornum to next_colornum in the dictionary
-    :param colors: Dictionary with property colornum as key and a list of vertices with that property as value
+    :param G: The graph currently evaluated
     :param colornum: Current colornum to be evaluated
     :param vertices: Vertices of that colornum to be evaluated
     :param next_colornum: The next colornum that was not in colors as a key before this colorgroup refinement
@@ -101,8 +96,8 @@ def __colorgroup_refinement(colors, colornum, vertices: List["Vertex"], next_col
     # After all vertices have been compared, change the colornum of all different vertices
     for v in different_vertices:
         v.colornum = next_colornum
-        colors.setdefault(next_colornum, []).append(v)
-        colors[colornum].remove(v)
+        G.colors.setdefault(next_colornum, []).append(v)
+        G.colors[colornum].remove(v)
         has_changed = True
 
     return has_changed
@@ -132,11 +127,10 @@ def __initialize_queue(G: "Graph"):
     :param G: The graph to construct the queue for
     :return: The queue of the graph
     """
-    colors = G.colors
-    queue = list(colors.keys())
+    queue = list(G.colors.keys())
     largest_color_group_size = 0
     largest_color_group = 0
-    for color, vertices in colors.items():
+    for color, vertices in G.colors.items():
         if len(vertices) > largest_color_group_size:
             largest_color_group = color
             largest_color_group_size = len(vertices)

--- a/algorithms/color_refinement.py
+++ b/algorithms/color_refinement.py
@@ -72,19 +72,6 @@ def fast_color_refinement(G: "Graph"):
     return G
 
 
-def get_colors(G: "Graph"):
-    """
-    Returns a map with the colors of the graph as keys and a list of all the vertices in the graph with that color as
-    values.
-    :param G: The graph
-    :return: The color map
-    """
-    colors = {}
-    for v in G.vertices:
-        colors.setdefault(v.colornum, []).append(v)
-    return colors
-
-
 def __colorgroup_refinement(colors, colornum, vertices: List["Vertex"], next_colornum):
     """
     For vertices with property colornum = 'colornum', define which vertices have equal neighbours and which do not

--- a/algorithms/color_refinement.py
+++ b/algorithms/color_refinement.py
@@ -11,7 +11,7 @@ def color_refinement(G: "Graph"):
     """
 
     # Get the current distribution of colors over the vertices
-    colors = get_colors(G)
+    colors = G.colors
 
     has_changed = True
     while has_changed:
@@ -44,7 +44,7 @@ def fast_color_refinement(G: "Graph"):
         # Get first color and remove that from the queue
         color = queue.pop(0)
         # Get the vertices of the graph in the color group currently investigated
-        colors = get_colors(G)
+        colors = G.colors
         vertices_in_color_group = colors[color]
         # Get the neighbours of the color group grouped by color
         neighbours_of_color_group = __get_color_groups_with_neighbours_in_color_group(vertices_in_color_group)
@@ -56,6 +56,9 @@ def fast_color_refinement(G: "Graph"):
             G.max_colornum += 1
             for vertex in color_group:
                 vertex.colornum = G.max_colornum
+                # Update colors of graph
+                colors[c].remove(vertex)
+                colors.setdefault(G.max_colornum, list()).append(vertex)
             # Add the correct color to the queue
             if c in queue:
                 queue.append(G.max_colornum)
@@ -142,7 +145,7 @@ def __initialize_queue(G: "Graph"):
     :param G: The graph to construct the queue for
     :return: The queue of the graph
     """
-    colors = get_colors(G)
+    colors = G.colors
     queue = list(colors.keys())
     largest_color_group_size = 0
     largest_color_group = 0

--- a/supporting_components/graph.py
+++ b/supporting_components/graph.py
@@ -440,6 +440,7 @@ class Graph(object):
         copy = Graph(self.directed)
         copy.max_colornum = self.max_colornum
         vertices_old_to_new = {}
+        colors = {}
 
         for v in self.vertices:
             vertices_old_to_new[v] = Vertex(copy)
@@ -447,11 +448,13 @@ class Graph(object):
             vertices_old_to_new[v].colornum = v.colornum
             vertices_old_to_new[v].graph_label = v.graph_label
             vertices_old_to_new[v].degree_fixed = v.degree_fixed
+            colors.setdefault(v.colornum, list()).append(v)
 
         for e in self.edges:
             edge = Edge(vertices_old_to_new[e.tail], vertices_old_to_new[e.head])
             copy.add_edge(edge)
 
+        copy.colors = colors
         return copy
 
     def is_equal(self, other):
@@ -477,15 +480,28 @@ class Graph(object):
         return len(other_vertices) == 0
 
     def backup(self):
+        """
+        Creates a backup of the color of each vertex in the graph, the maximum colornum and the color map of vertices grouped by color.
+        :return: Two structures with vertices and color and the maximum colornum
+        """
         color_list = {}
+        colors = {}
         for v in self.vertices:
             color_list[v.label] = v.colornum
-        return color_list, self.max_colornum
+            colors.setdefault(v.colornum, list()).append(v)
+        return color_list, self.max_colornum, colors
 
-    def revert(self, color_list: "Dict[int]", max_colornum):
+    def revert(self, color_list: "Dict[int]", max_colornum: "int", colors: "Dict[int, List[Vertex]]"):
+        """
+        Convert a graph to the state of the arguments
+        :param color_list: The map of vertices with its color
+        :param max_colornum: The maximum colornum
+        :param colors: The map of color with its vertices
+        """
         for v in self.vertices:
             v.colornum = color_list[v.label]
         self.max_colornum = max_colornum
+        self.colors = colors
 
 
 class UnsafeGraph(Graph):

--- a/supporting_components/graph.py
+++ b/supporting_components/graph.py
@@ -448,7 +448,7 @@ class Graph(object):
             vertices_old_to_new[v].colornum = v.colornum
             vertices_old_to_new[v].graph_label = v.graph_label
             vertices_old_to_new[v].degree_fixed = v.degree_fixed
-            colors.setdefault(v.colornum, list()).append(v)
+            colors.setdefault(v.colornum, list()).append(vertices_old_to_new[v])
 
         for e in self.edges:
             edge = Edge(vertices_old_to_new[e.tail], vertices_old_to_new[e.head])


### PR DESCRIPTION
De get_colors methode om een map te maken van de vertices per kleur is nu niet meer nodig. De graaf heeft zelf deze map bij zich en update die wanneer nodig, ook wordt deze gerevert wanneer nodig.
De tijden van Torus144_0-6 was op de huidige master 9.717 seconden voor fast en 3.78 seconden voor normaal color refinen (geen idee waarom de fast hier langer duurt). De tijden op deze branch na de wijzigingen zijn 2.79 seconden voor fast en 3.69 voor normaal color refinen. 
De tijden van Cubes6_2-3 is op de huidige master 140 seconden voor fast color refinement (voor normaal duurt het nog langer, maar heb ik niet op gewacht). De tijden op de branch na de wijzigingen zijn 48 seconden voor fast en 61 seconden voor normaal color refinen.
Het scheelt dus wel een hoop tijd, maar vooral op grote grafen die al lang duren. Op kleinere grafen heb ik het niet specifiek uitgezocht hoeveel tijd het scheelt