### PR TITLE
Add tournament output, fixes #76

### DIFF
--- a/input_output/sys_output.py
+++ b/input_output/sys_output.py
@@ -34,7 +34,7 @@ WHITE_BG= '47'
 
 FAIL_COLOR = START + BOLD + DELIMITER + RED_FONT + END
 PASS_COLOR = START + BOLD + DELIMITER + GREEN_FONT + END
-
+TOURNAMENT_TITLE = START + BOLD + DELIMITER + BLUE_FONT + END
 
 def fail(string):
     print(FAIL_COLOR + string + RESET)
@@ -42,3 +42,7 @@ def fail(string):
 
 def passed(string):
     print(PASS_COLOR + string + RESET)
+
+
+def title(string):
+    print(TOURNAMENT_TITLE + string + RESET)

--- a/tests/integration_test/run_tournament.py
+++ b/tests/integration_test/run_tournament.py
@@ -1,0 +1,114 @@
+# Util imports
+from input_output.file_output import load_graph_list_from_filepath, create_csv_file, write_csv_line
+from input_output.sys_output import title, passed
+import tkinter as tk
+from tkinter import filedialog
+from time import time
+# Algorithm imports
+from tests.integration_test.settings import *
+from tests.integration_test.isomorphism_problem import are_isomorph, amount_of_isomorphisms
+
+"""
+General integration test for the Graph Isomorphisms problem.
+Settings of the algorithm must be changed in > settings.py <
+"""
+
+"""
+FILE INPUT
+"""
+# Select files to evaluate
+root = tk.Tk()
+root.withdraw()
+file_paths = filedialog.askopenfilenames()
+
+"""
+FILE OUTPUT
+"""
+# TODO: ADAPT TO TOURNAMENT
+# If csv must be created, create an empty file here
+if tournament_write_to_csv:
+    csv_filepath = create_csv_file("tournament")
+    # Write first row with column names
+    csv_column_names = ['file', 'graph1', 'graph2',
+                        'are_isomorph expected result', 'are_isomorph actual result', 'passed', 'are_isomorph processing time (s)',
+                        'amount_of_isomorphisms expected result', 'amount_of_isomorphisms actual result', 'passed', 'amount_of_isomorphisms processing time (s)']
+    write_csv_line(csv_filepath, csv_column_names)
+
+
+"""
+RUN TOURNAMENT
+"""
+for filepath in file_paths:
+    graphs = load_graph_list_from_filepath(filepath)
+    filename = (filepath.split("/")[-1]).split(".")[0]
+
+    passed("Starting evaluating " + filename)
+
+    # Dependent on problem to be solved, create loop for first graph
+    if problem == 1 or problem == 2:
+        i_loop = range(len(graphs)-1)
+    else:
+        i_loop = range(len(graphs))
+
+    if problem == 1:
+        results = []
+    elif problem == 2 or problem == 3:
+        results = {}
+    total_time = 0
+    for i in i_loop:
+        # Dependent on problem to be solved, create loop for second graph
+        if problem == 1 or problem == 2:
+            j_loop = range(i + 1, len(graphs))
+        else:
+            j_loop = [i]
+        for j in j_loop:
+            G = graphs[i]
+            H = graphs[j]
+
+            if problem == 1 or problem == 2:
+                G_copy = G.copy()
+                H_copy = H.copy()
+                start_isomorph = time()
+                are_isomorph_actual = are_isomorph(G_copy, H_copy)
+                end_isomorph = time()
+                total_time += round((end_isomorph - start_isomorph), 3)
+                if problem == 1 and are_isomorph_actual:
+                    results.append((i, j))
+
+            if problem == 2 or problem == 3:
+                G_copy = G.copy()
+                H_copy = H.copy()
+                start_amount_isomorphisms = time()
+                amount_isomorph_actual = amount_of_isomorphisms(G_copy, H_copy)
+                end_amount_isomorphisms = time()
+                total_time += round((end_amount_isomorphisms - start_amount_isomorphisms), 3)
+                if problem == 2 and are_isomorph_actual:
+                    results[(i, j)] = amount_isomorph_actual
+                if problem == 3:
+                    results[i] = amount_isomorph_actual
+
+    print("-------------------------------")
+    print("Results " + filename)
+    print("-------------------------------")
+    if problem == 1:
+        title("Sets of isomorphic graphs:")
+    elif problem == 2:
+        title("Sets of isomorphic graphs:   Number of isomorphisms:")
+    elif problem == 3:
+        title("Graph:   Number of automorphisms:")
+    for key in results:
+        if problem == 1:
+            print(str(key))
+        elif problem == 2:
+            print(str(key) + "                       " + str(results[key]))
+        elif problem == 3:
+            print(str(key) + "        " + str(results[key]))
+    print("")
+
+    # if write_to_csv:
+    #     csv_graph_result = [filename, i, j,
+    #                         are_isomorph_expected, are_isomorph_actual, are_isomorph_passed, are_isomorph_time,
+    #                         amount_isomorph_expected, amount_isomorph_actual, amount_isomorph_passed, amount_isomorph_time]
+    #     write_csv_line(csv_filepath, csv_graph_result)
+
+

--- a/tests/integration_test/run_tournament.py
+++ b/tests/integration_test/run_tournament.py
@@ -33,7 +33,7 @@ for filepath in file_paths:
     isomorphisms = []       # Data structure that saves all isomorphic pairs (or more than 2, if that is the case)
     iso_count = {}          # Data structure that saves for each graph the amount of automorphisms
     total_time = 0
-    skip = [False for _ in range(len(graphs))]  # Check if the pair of graphs is already in the result, it they are, they can be skipped
+    skip = [False for _ in range(len(graphs))]  # Check if the pair of graphs is already in the result, if they are, they can be skipped
 
     # In this first loop, for each combination, it is determined if they are isomorphic or not
     for i in range(len(graphs) - 1):

--- a/tests/integration_test/run_tournament.py
+++ b/tests/integration_test/run_tournament.py
@@ -33,11 +33,16 @@ for filepath in file_paths:
     isomorphisms = []       # Data structure that saves all isomorphic pairs (or more than 2, if that is the case)
     iso_count = {}          # Data structure that saves for each graph the amount of automorphisms
     total_time = 0
+    skip = [False for _ in range(len(graphs))]  # Check if the pair of graphs is already in the result, it they are, they can be skipped
+
     # In this first loop, for each combination, it is determined if they are isomorphic or not
     for i in range(len(graphs) - 1):
         for j in range(i + 1, len(graphs)):
             G = graphs[i]
             H = graphs[j]
+
+            if skip[i] and skip[j]:
+                continue
 
             G_copy = G.copy()
             H_copy = H.copy()
@@ -50,32 +55,29 @@ for filepath in file_paths:
             # of each graph, then save each graph in de isomorphisms data structure.
             if are_isomorph_actual:
                 # If one of the two graphs is already in a isomorphic pair, the other graph belongs to it too
-                already_in_results = -1
-                for pair in isomorphisms:
-                    if i in pair:
-                        pair.append(j)
-                        already_in_results = i
-                        break
-                    elif j in pair:
-                        pair.append(i)
-                        already_in_results = j
-                        break
-                # Otherwise a new pair of isomorphisms should be added to the list
-                if already_in_results < 0:
-                    isomorphisms.append([i, j])
-            else:
-                if problem == 3:
-                    # If graphs are not isomorphic, check for each one if it is already in the isomorphic data structure
-                    # If not, add it
-                    i_in_result = False
-                    j_in_result = False
+                if skip[i] or skip[j]:
                     for pair in isomorphisms:
-                        i_in_result = i_in_result or i in pair
-                        j_in_result = j_in_result or j in pair
-                    if not i_in_result:
-                        isomorphisms.append([i])
-                    if not j_in_result:
-                        isomorphisms.append([j])
+                        if i in pair:
+                            pair.append(j)
+                            skip[j] = True
+                            break
+                        elif j in pair:
+                            pair.append(i)
+                            skip[i] = True
+                            break
+                # Otherwise a new pair of isomorphisms should be added to the list
+                else:
+                    isomorphisms.append([i, j])
+                    skip[i] = True
+                    skip[j] = True
+
+    # If the problem to be resolved is the #Automorphism problem, all graphs need to be in de result, also those
+    # that are not an isomorphism with any other graph. Those graphs will be added to the isomorphism result as
+    # singular isomorphism groups
+    if problem == 3:
+        for i in range(len(skip)):
+            if not skip[i]:
+                isomorphisms.append([i])
 
     # For each set of isomorphisms, calculate the amount of automorphisms of the first graph. This can be done
     # because the graphs are isomorphic and the amount of isomorphisms are equal to the amount of automorphisms of the

--- a/tests/integration_test/run_tournament.py
+++ b/tests/integration_test/run_tournament.py
@@ -44,48 +44,62 @@ for filepath in file_paths:
 
     passed("Starting evaluating " + filename)
 
-    # Dependent on problem to be solved, create loop for first graph
-    if problem == 1 or problem == 2:
-        i_loop = range(len(graphs)-1)
-    else:
-        i_loop = range(len(graphs))
-
-    if problem == 1:
-        results = []
-    elif problem == 2 or problem == 3:
-        results = {}
+    isomorphisms = []
+    iso_count = {}
     total_time = 0
-    for i in i_loop:
-        # Dependent on problem to be solved, create loop for second graph
-        if problem == 1 or problem == 2:
-            j_loop = range(i + 1, len(graphs))
-        else:
-            j_loop = [i]
-        for j in j_loop:
+    for i in range(len(graphs) - 1):
+        for j in range(i + 1, len(graphs)):
             G = graphs[i]
             H = graphs[j]
 
-            if problem == 1 or problem == 2:
-                G_copy = G.copy()
-                H_copy = H.copy()
-                start_isomorph = time()
-                are_isomorph_actual = are_isomorph(G_copy, H_copy)
-                end_isomorph = time()
-                total_time += round((end_isomorph - start_isomorph), 3)
-                if problem == 1 and are_isomorph_actual:
-                    results.append((i, j))
+            G_copy = G.copy()
+            H_copy = H.copy()
+            start_isomorph = time()
+            are_isomorph_actual = are_isomorph(G_copy, H_copy)
+            end_isomorph = time()
+            total_time += round((end_isomorph - start_isomorph), 3)
 
-            if problem == 2 or problem == 3:
-                G_copy = G.copy()
-                H_copy = H.copy()
-                start_amount_isomorphisms = time()
-                amount_isomorph_actual = amount_of_isomorphisms(G_copy, H_copy)
-                end_amount_isomorphisms = time()
-                total_time += round((end_amount_isomorphisms - start_amount_isomorphisms), 3)
-                if problem == 2 and are_isomorph_actual:
-                    results[(i, j)] = amount_isomorph_actual
+            # Every combination should be checked
+            if are_isomorph_actual:
+                # Only save results if the combination of graphs is isomorphic
+                # If one of the two graphs is already in a isomorphic pair, the other graph belongs to it too
+                already_in_results = -1
+                for pair in isomorphisms:
+                    if i in pair:
+                        pair.append(j)
+                        already_in_results = i
+                        break
+                    elif j in pair:
+                        pair.append(i)
+                        already_in_results = j
+                        break
+                # Otherwise a new pair of isomorphisms should be added to the list
+                if already_in_results < 0:
+                    isomorphisms.append([i, j])
+            else:
                 if problem == 3:
-                    results[i] = amount_isomorph_actual
+                    # Also save if graphs are not isomorphic
+                    i_in_result = False
+                    j_in_result = False
+                    for pair in isomorphisms:
+                        i_in_result = i_in_result or i in pair
+                        j_in_result = j_in_result or j in pair
+                    if not i_in_result:
+                        isomorphisms.append([i])
+                    if not j_in_result:
+                        isomorphisms.append([j])
+
+    if problem == 2 or problem == 3:
+        # For each set of isomorphisms, calculate the amount of automorphisms of the first graph
+        for pair in isomorphisms:
+            G_copy1 = graphs[pair[0]].copy()
+            G_copy2 = graphs[pair[0]].copy()
+            start_amount_isomorphisms = time()
+            amount_isomorph_actual = amount_of_isomorphisms(G_copy1, G_copy2)
+            end_amount_isomorphisms = time()
+            total_time += round((end_amount_isomorphisms - start_amount_isomorphisms), 3)
+            for graph in pair:
+                iso_count[graph] = amount_isomorph_actual
 
     print("-------------------------------")
     print("Results " + filename)
@@ -96,13 +110,18 @@ for filepath in file_paths:
         title("Sets of isomorphic graphs:   Number of isomorphisms:")
     elif problem == 3:
         title("Graph:   Number of automorphisms:")
-    for key in results:
-        if problem == 1:
-            print(str(key))
-        elif problem == 2:
-            print(str(key) + "                       " + str(results[key]))
-        elif problem == 3:
-            print(str(key) + "        " + str(results[key]))
+
+    if problem == 1 or problem == 2:
+        for pair in isomorphisms:
+            if problem == 1:
+                print(str(pair))
+            elif problem == 2:
+                print(str(pair) + "                       " + str(iso_count[pair[0]]))
+    elif problem == 3:
+        for g in sorted(iso_count):
+            print(str(g) + "        " + str(iso_count[g]))
+
+    print("Total processing time: " + str(round(total_time, 3)) + " s")
     print("")
 
     # if write_to_csv:

--- a/tests/integration_test/settings.py
+++ b/tests/integration_test/settings.py
@@ -10,6 +10,17 @@ console_pass = True
 write_to_csv = True
 
 """
+TOURNAMENT SETTINGS
+"""
+# When set to true, test results are written to a csv file
+tournament_write_to_csv = True
+# Set this parameter to the right setting to indicate which algorithms to run
+# 1) Graph Isomorphism Problem - Determine if two different graphs are isomorphic
+# 2) Count Isomorphisms - Next to 1) also count the amount of isomorphisms
+# 3) Count Automorphisms - Count automorphisms within one graph
+problem = 3
+
+"""
 SETTINGS OF ALGORITHM
 """
 # Choose which preprocessing steps you want to have by turning them to True


### PR DESCRIPTION
Voor het toernooi 10 april is om een bepaalde output op de console gevraagd in de Project guide. Hiervoor is een nieuwe file run_tournament gemaakt, die van dezelfde settings gebruik maakt als de integratie test.

Verder is het ook nog mogelijk om dezelfde output op te slaan in een csv file, zodat de gegevens niet verloren gaan mochten we per ongeluk de console output wegklikken.

Met de volgende opmerkingen uit de guide heb ik ook rekening gehouden:
* **_It is not guaranteed that isomorphic graphs will always occur in pairs, as was
accidentally true for the test instances._** 
Dus ik heb ervoor gezorgd dat je ook 3 of meer grafen in eenzelfde set van isomorphismen kan hebben.
* **_In particular, observe that it makes very little sense to count the number of automorphisms of more than one graph per equivalence class_**
Wat ik daarom heb gedaan is eerst voor alle combinaties van grafen bepalen of ze isomorph zijn of niet. Daarna bepaal ik van elke eerste graaf in de set van isomorphismen het aantal automorphismen.