### PR TITLE
Preprocessing complement

### DIFF
--- a/algorithms/preprocessing.py
+++ b/algorithms/preprocessing.py
@@ -100,3 +100,16 @@ def neighbours_equal(v0_neighbours: "List[Vertex]", v1_neighbours: "List[Vertex]
         else:
             return False
     return len(v1_neighbours) == 0
+
+
+def use_complement(G: "Graph"):
+    """
+    Whether or not the graph has more edges than half of the maximal number of edges for the graph.
+    If this is true, further processing with the complement of G will likely be faster.
+    :param G: The graph
+    :return: Whether or not the complement should be used for further processing
+    """
+    number_of_vertices = len(G.vertices)
+    number_of_edges = len(G.edges)
+    max_edges = (number_of_vertices * (number_of_vertices - 1)) / 2
+    return number_of_edges > (max_edges/2)

--- a/supporting_components/graph.py
+++ b/supporting_components/graph.py
@@ -227,6 +227,7 @@ class Graph(object):
         self._directed = directed
         self._next_label_value = 0
         self.max_colornum = 0
+        self.colors = {}
 
         for i in range(n):
             self.add_vertex(Vertex(self))
@@ -506,6 +507,27 @@ class Graph(object):
             v.colornum = color_list[v.label]
         self.max_colornum = max_colornum
         self.colors = colors
+
+    def complement(self):
+        """
+        Create the complement of the graph.
+        :return: The complement
+        """
+        complement = Graph(self.directed)
+        vertices_original_to_complement = {}
+
+        # Create vertex mapping from original graph to complement graph
+        for v in self.vertices:
+            vertices_original_to_complement[v] = Vertex(complement)
+            vertices_original_to_complement[v].label = v.label
+        # Add edge to complement graph only if the edge does not exist in the original graph and no undirected edge is
+        # already present in the complement graph between those two vertices
+        for v in self.vertices:
+            neighbours = v.neighbours
+            for w in self.vertices:
+                if w not in neighbours and v != w and not any((edge.tail == vertices_original_to_complement[v] and edge.head == vertices_original_to_complement[w]) or (edge.head == vertices_original_to_complement[v] and edge.tail == vertices_original_to_complement[w]) for edge in complement.edges):
+                    complement.add_edge(Edge(vertices_original_to_complement[v], vertices_original_to_complement[w]))
+        return complement
 
 
 class UnsafeGraph(Graph):

--- a/supporting_components/graph.py
+++ b/supporting_components/graph.py
@@ -520,6 +520,7 @@ class Graph(object):
         for v in self.vertices:
             vertices_original_to_complement[v] = Vertex(complement)
             vertices_original_to_complement[v].label = v.label
+            vertices_original_to_complement[v].degree_fixed = v.degree_fixed
         # Add edge to complement graph only if the edge does not exist in the original graph and no undirected edge is
         # already present in the complement graph between those two vertices
         for v in self.vertices:

--- a/tests/graph.py
+++ b/tests/graph.py
@@ -14,6 +14,35 @@ def test_copy(graph):
     return copy.is_equal(graph)
 
 
+def test_complement(G: "Graph"):
+    """
+    Tests the complement method of the graph.
+    :param G: The graph
+    :return: Whether or not the complement is correctly
+    """
+    complement = G.complement()
+    max_edges = (len(G.vertices) * (len(G.vertices) - 1)) / 2
+    return len(complement.edges) + len(G.edges) == max_edges and test_incidence_complement(G, complement)
+
+
+def test_incidence_complement(G: "Graph", complement: "Graph"):
+    """
+    Tests whether or not the incidences of the vertices in the graphs are completely different.
+    :param G: The graph
+    :param complement: The complement of the graph
+    :return: Whether or not the incidences of the vertices are completely different
+    """
+    # Loop over both lists of vertices
+    for v in G.vertices:
+        for w in complement.vertices:
+            if v.label == w.label:
+                # If the labels of the vertices are the same (so they resemble the same vertex)
+                for i in v.incidence:
+                    if i in w.incidence:
+                        return False
+    return True
+
+
 def unit_test(write_csv_any=False, write_stdout_passed=True, write_stdout_fail=True):
     test_name = 'graph'
     if write_csv_any:
@@ -42,6 +71,7 @@ def unit_test(write_csv_any=False, write_stdout_passed=True, write_stdout_fail=T
                 graph = graphs[i] + graphs[j]
                 color_refinement(degree_color_initialization(graph))
                 is_equal = test_copy(graph)
+                is_correct_complement = test_complement(graph)
                 if not is_equal:
                     error_count += 1
                     if write_stdout_fail:
@@ -50,11 +80,19 @@ def unit_test(write_csv_any=False, write_stdout_passed=True, write_stdout_fail=T
                         fail("Is NOT copy equal to graph: " + str(is_equal))
                     if write_csv_any:
                         write_csv_line(csv_filepath, [file, str(i), str(j), False, "{0:.3f}".format(0)])
+                if not is_correct_complement:
+                    error_count += 1
+                    if write_stdout_fail:
+                        print('---------------------------')
+                        print("Statistics of " + file + "-" + str(i) + "_" + str(j) + ":")
+                        fail("Is complement constructed correctly: " + str(is_correct_complement))
+                    if write_csv_any:
+                        write_csv_line(csv_filepath, [file, str(i), str(j), False, "{0:.3f}".format(0)])
                 else:
                     if write_stdout_passed:
                         print('---------------------------')
                         print("Statistics of " + file + "-" + str(i) + "_" + str(j) + ":")
-                        passed("Is copy equal to graph: " + str(is_equal))
+                        passed("Is copy equal to graph and complement constructed correctly: " + str(is_equal) + " and " + str(is_correct_complement))
                     if write_csv_any:
                         write_csv_line(csv_filepath, [file, str(i), str(j), True, "{0:.3f}".format(0)])
 

--- a/tests/integration_test/algorithm_options.py
+++ b/tests/integration_test/algorithm_options.py
@@ -1,6 +1,6 @@
-from tests.integration_test.settings import simple_cases, twin_removal, tree_algorithm, color_refinement_algorithm, branching_algorithm
+from tests.integration_test.settings import simple_cases, twin_removal, tree_algorithm, color_refinement_algorithm, branching_algorithm, complement
 from supporting_components.graph import Graph
-from algorithms.preprocessing import could_be_isomorphic, remove_twins
+from algorithms.preprocessing import could_be_isomorphic, remove_twins, use_complement
 from algorithms.tree_algorithm import is_tree, trees_count_isomorphisms
 from algorithms.color_initialization import degree_color_initialization, twins_color_initialization
 from algorithms.color_refinement import color_refinement, fast_color_refinement
@@ -70,3 +70,17 @@ def branching_method(G: "Graph", count_flag: "Bool"):
     """
     if branching_algorithm == 1:
         return count_isomorphisms(G, [], [], count_flag, color_refinement_method())
+
+
+def apply_complement(G: "Graph"):
+    """
+    If complement is set to True in the settings of the integration test, a check is done if it is beneficial if the
+    complement of the graph is used in further processing.
+    If the complement should be used, the complement is returned, otherwise the original graph is returned.
+    :param G: The graph to check for if using the complement will result in faster result
+    :return: The (complement of the) graph
+    """
+    if complement:
+        if use_complement(G):
+            return complement(G)
+    return G

--- a/tests/integration_test/algorithm_options.py
+++ b/tests/integration_test/algorithm_options.py
@@ -82,5 +82,5 @@ def apply_complement(G: "Graph"):
     """
     if complement:
         if use_complement(G):
-            return complement(G)
+            return G.complement()
     return G

--- a/tests/integration_test/isomorphism_problem.py
+++ b/tests/integration_test/isomorphism_problem.py
@@ -1,5 +1,5 @@
 from algorithms.preprocessing import fix_degrees
-from tests.integration_test.algorithm_options import apply_could_be_isomorphic, apply_remove_twins, apply_tree_algorithm, branching_method
+from tests.integration_test.algorithm_options import apply_could_be_isomorphic, apply_remove_twins, apply_tree_algorithm, branching_method, apply_complement
 
 """
 With these methods, the graph isomorphism problem can be solved.
@@ -14,6 +14,9 @@ def are_isomorph(G: "Graph", H: "Graph"):
 
     if not apply_could_be_isomorphic(G, H):
         return False
+
+    G = apply_complement(G)
+    H = apply_complement(H)
 
     G_disjoint_union, _ = apply_remove_twins(G, H)
 

--- a/tests/integration_test/settings.py
+++ b/tests/integration_test/settings.py
@@ -28,6 +28,7 @@ SETTINGS OF ALGORITHM
 simple_cases = True
 twin_removal = True
 tree_algorithm = True
+complement = True
 
 # Choose a color refinement algorithm
 # 1 - normal color refinement


### PR DESCRIPTION
Er is nu een preprocessing optie dat je verder rekent met de complement als deze minder edges heeft dan de originele graaf. Dit wordt alleen gedaan bij are_isomorph, omdat je voor het aantal isomorfismen toch met de originele grafen moet werken.
 Ik heb het met een bult van de grafen geprobeerd, maar nergens lijkt het nu efficienter te zijn om de complement te berekenen. Maar misschien dat het bij het toernooi wel zo is. Ik denk op zich dat het geen kwaad kan om het erin te hebben zitten en je kunt de preprocessing altijd uitzetten. 